### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,65 @@
+# Builds and deploys the page to github pages.
+name: Deploy to GitHub Pages
+
+on:
+    # Runs on pushes targeting the `main` branch.
+    push:
+        branches: [main]
+
+    # Allows us to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+    group: pages
+    cancel-in-progress: false
+
+jobs:
+    # Build job
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+
+            - name: Setup Pages
+              uses: actions/configure-pages@v4
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Build with Next
+              run: npm run build
+
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: ./out
+
+    # Deployment job
+    deploy:
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+
+        needs: build
+        runs-on: ubuntu-latest
+        name: Deploy
+
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR adds the workflow for deployment to github pages.

**Please note:** before merging this PR, the _repository needs to be public_[^1] and the [pages settings](https://github.com/inf-lab-dev/advent/settings/pages) need to be properly configured.[^2] Otherwise the workflow will fail.

Thus, only merge this workflow once everything is finished. Additionally, after merging and **after the page has successfuly deployed** the PR at https://github.com/inf-lab-dev/page/pull/16 can be merged.

[^1]: Once the repository becomes public, the branch protection rules get enforced, thus this PR becomes a review-required PR.
[^2]: This means, the source has to be configured to be _GitHub Actions_, the custom domain needs to be _advent.inf-lab.dev_ and the _Enforce HTTPs_ checkbox needs to be checked. If one of those settings is not correct, either the workflow will fail or the page will behave weirdly due to wrong base-paths. The domain _advent.inf-lab.dev_ already has the matching `CNAME` record in its DNS-Settings.